### PR TITLE
fix(validation): allow environment variable names with leading underscore

### DIFF
--- a/circleci/validation.go
+++ b/circleci/validation.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	// https://circleci.com/docs/2.0/env-vars/#injecting-environment-variables-with-the-api
-	environmentVariablePrefixRegex = regexp.MustCompile("^[[:alpha:]]")
+	environmentVariablePrefixRegex = regexp.MustCompile("^[[:alpha:]_]")
 	environmentVariableCharsRegex  = regexp.MustCompile("^[[:word:]]+$")
 )
 
@@ -19,7 +19,7 @@ func validateEnvironmentVariableNameFunc(v interface{}, key string) (warns []str
 	}
 
 	if !environmentVariablePrefixRegex.MatchString(name) {
-		errs = append(errs, errors.New("environment variables may only begin with a letter"))
+		errs = append(errs, errors.New("environment variables may only begin with a letter or an underscore"))
 	}
 
 	if !environmentVariableCharsRegex.MatchString(name) {

--- a/circleci/validation_test.go
+++ b/circleci/validation_test.go
@@ -17,6 +17,9 @@ func TestValidateEnvironmentVariableName(t *testing.T) {
 			Name: "VALID_UNDERSCORE_",
 		},
 		{
+			Name: "_VALID_LEADING_UNDERSCORE",
+		},
+		{
 			Name: "VALID_DIGIT_1",
 		},
 		{
@@ -25,10 +28,6 @@ func TestValidateEnvironmentVariableName(t *testing.T) {
 		},
 		{
 			Name:  "1_invalid_leading_digit",
-			Error: true,
-		},
-		{
-			Name:  "_invalid_leading_underscore",
 			Error: true,
 		},
 	}


### PR DESCRIPTION
as per the CircleCI documentation

Fixes #3 