### PR TITLE
Implement Rate Limiting

### DIFF
--- a/circleci/client/rest/client.go
+++ b/circleci/client/rest/client.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -60,36 +61,50 @@ func (c *Client) NewRequest(method string, u *url.URL, payload interface{}) (req
 }
 
 func (c *Client) DoRequest(req *http.Request, resp interface{}) (statusCode int, err error) {
-	httpResp, err := c.client.Do(req)
-	if err != nil {
-		return 0, err
-	}
-	defer httpResp.Body.Close()
-
-	if httpResp.StatusCode >= 300 {
-		httpError := struct {
-			Message string `json:"message"`
-		}{}
-		err = json.NewDecoder(httpResp.Body).Decode(&httpError)
+	for {
+		httpResp, err := c.client.Do(req)
 		if err != nil {
-			return httpResp.StatusCode, err
+			return 0, err
 		}
-		return httpResp.StatusCode, &HTTPError{Code: httpResp.StatusCode, Message: httpError.Message}
-	}
 
-	if resp != nil {
-		// REST API v2 does not currently return Content-Type
+		if httpResp.StatusCode == http.StatusTooManyRequests {
+			httpResp.Body.Close()
+			rateLimitReset, err := strconv.ParseInt(httpResp.Header.Get("x-ratelimit-reset"), 10, 64)
+			if err != nil {
+				return httpResp.StatusCode, fmt.Errorf("could not parse rate limit reset header: %v", err)
+			}
 
-		// if !strings.Contains(httpResp.Header.Get("Content-Type"), "application/json") {
-		// 	return httpResp.StatusCode, errors.New("wrong content type received")
-		// }
-
-		err = json.NewDecoder(httpResp.Body).Decode(resp)
-		if err != nil {
-			return httpResp.StatusCode, fmt.Errorf("could not decode response: %v", err)
+			time.Sleep(time.Duration(rateLimitReset) * time.Second)
+			return c.DoRequest(req, resp)
 		}
+
+		defer httpResp.Body.Close()
+
+		if httpResp.StatusCode >= 300 {
+			httpError := struct {
+				Message string `json:"message"`
+			}{}
+			err = json.NewDecoder(httpResp.Body).Decode(&httpError)
+			if err != nil {
+				return httpResp.StatusCode, err
+			}
+			return httpResp.StatusCode, &HTTPError{Code: httpResp.StatusCode, Message: httpError.Message}
+		}
+
+		if resp != nil {
+			// REST API v2 does not currently return Content-Type
+
+			// if !strings.Contains(httpResp.Header.Get("Content-Type"), "application/json") {
+			// 	return httpResp.StatusCode, errors.New("wrong content type received")
+			// }
+
+			err = json.NewDecoder(httpResp.Body).Decode(resp)
+			if err != nil {
+				return httpResp.StatusCode, fmt.Errorf("could not decode response: %v", err)
+			}
+		}
+		return httpResp.StatusCode, nil
 	}
-	return httpResp.StatusCode, nil
 }
 
 type HTTPError struct {

--- a/circleci/client/rest/client_test.go
+++ b/circleci/client/rest/client_test.go
@@ -1,0 +1,76 @@
+package rest
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+)
+
+func TestClient_RateLimit(t *testing.T) {
+	var requests int
+
+	// Mock server that will return a 429 on the first call
+	// and a 200 on the second call.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+
+		if requests == 1 {
+			w.Header().Set("x-ratelimit-reset", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL, "v2", "test-token")
+
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/test", ts.URL), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	start := time.Now()
+	statusCode, err := c.DoRequest(req, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	duration := time.Since(start)
+
+	if statusCode != http.StatusOK {
+		t.Errorf("expected status code %d, got %d", http.StatusOK, statusCode)
+	}
+
+	if requests != 2 {
+		t.Errorf("expected 2 requests, got %d", requests)
+	}
+
+	if duration < 1*time.Second {
+		t.Errorf("expected to wait at least 1 second, but waited %s", duration)
+	}
+}
+
+func TestClient_NewRequest(t *testing.T) {
+	c := New("https://circleci.com", "api/v2", "test-token")
+	if c.baseURL.String() != "https://circleci.com/api/v2/" {
+		t.Errorf("expected base URL to be https://circleci.com/api/v2/, got %s", c.baseURL.String())
+	}
+
+	u, _ := url.Parse("test")
+	req, err := c.NewRequest("GET", u, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if req.URL.String() != "https://circleci.com/api/v2/test" {
+		t.Errorf("expected URL to be https://circleci.com/api/v2/test, got %s", req.URL.String())
+	}
+
+	if req.Header.Get("Circle-Token") != "test-token" {
+		t.Error("missing Circle-Token header")
+	}
+}


### PR DESCRIPTION
This was vibe coded with Gemini based on the following prompt:

> See this issue: https://github.com/SectorLabs/terraform-provider-circleci/issues/6.  Implement code to gracefully handle rate limiting, per https://circleci.com/docs/api-developers-guide/#rate-limits.  The HTTP requests to the CircleCI API should wait the duration of the time window specified by the rate limit headers in the HTTP response from the CircleCI API.

---

Followup Prompts:

> The logic in the previous change is not correct.  The X-RateLimit-Reset header
> does not contain a unix timestamp.  It is the number of seconds to wait.

---

> add a test for the rate limiting functionality

---

> let's revisit the changes made to the current feature branch.  I think on line
> 78 of @circleci/client/rest/client.go that we need to make a recursive call
> back to the DoRequest function instead of calling continue.